### PR TITLE
workbook.css

### DIFF
--- a/css/app/workbook.css
+++ b/css/app/workbook.css
@@ -450,6 +450,13 @@
 	font-weight: 600;
 	color: #3E2723;
 }
+@media (max-width: 991px) {
+    .workbook-index-section .book-section {
+		width: calc(100vw - 7rem);
+		border: none;
+		padding: 5px;
+	}
+}
 @media (max-width: 768px) {
     .workbook-index-section .book-section {
 		width: calc(100vw - 1rem);


### PR DESCRIPTION
워크북 인덱스 메뉴의 태블릿 세로사이즈 디자인 버그 수정