### PR TITLE
Update summernote.editor.js

### DIFF
--- a/js/util/summernote.editor.js
+++ b/js/util/summernote.editor.js
@@ -38,7 +38,6 @@ async function openSummernote($input) {
 					// Firefox fix
 					setTimeout(function () {
 						$input.summernote('pasteHTML', bufferText.replaceAll(/\n/g,'<br/>'));
-						// document.execCommand('insertText', false, bufferText);
 					}, 10);
 				}
 			},
@@ -46,11 +45,13 @@ async function openSummernote($input) {
 				const maxContents = 65000,
 					popover = bootstrap.Popover.getOrCreateInstance($editable[0], 
 									{html: true, title: '<span class="fw-bold">※ 경고</span>',
+									trigger: 'manual',
 									content: '<span class="fw-bold text-danger">본문 내용이 너무 길어 '
-										+ maxContents + '자를 초과한 글자는 제거되었습니다.</span>'});
+										+ '마지막 입력이 취소되었습니다.</span>'});
 				if(contents.length > maxContents) {
-					$(this).summernote('code',contents.substring(0, maxContents));
-					popover.show();
+					$(this).summernote('undo');
+					setTimeout(() => popover.show(), 150);
+					$editable.blur();
 				}else popover.hide();
 			},			
 			onImageUpload: function(files) {


### PR DESCRIPTION
- 입력글자제한 popover가 함수 호출이 아닌 클릭 등으로 인해 자동 표시되지 않도록 수정.
- 초과입력시 본문태그의 끝 몇 자를 잘라내는 것은 DOM 오류를 발생시킬 수 있으므로 
마지막 입력을 undo()하는 것으로 수정.
- 연속된 입력으로 메세지를 못 볼 수 있기 때문에 본문에 blur() 실행 후 popover 표시.