### PR TITLE
Update workbook.css

### DIFF
--- a/css/app/workbook.css
+++ b/css/app/workbook.css
@@ -975,13 +975,17 @@
       opacity: 0.7;
    }
 }
-/* 지문 수정 */
+/* 워크북 수정 및 개요보기 */
 .edit-workbook-section .passage,
 .overview-workbook-section .passage {
 	counter-increment: psgCounter;
 	word-break: break-all;
 }
-.edit-workbook-section .passage::before,
+.edit-workbook-section .passage-text {
+	display: 'block';
+}
+/* 지문 번호 표시(수정화면엔 지문 수정메뉴 툴팁이 있으므로, 자식요소에 적용) */
+.edit-workbook-section .passage-text::before,
 .overview-workbook-section .passage::before { 
 	content: counter(psgCounter);
 	color: white;


### PR DESCRIPTION
워크북 수정화면의 지문 블럭에서 문장 사이를 클릭하면 지문 상세보기로 이동이 안되는 버그 수정.