### PR TITLE
Update tandem.css

### DIFF
--- a/css/app/tandem.css
+++ b/css/app/tandem.css
@@ -172,7 +172,7 @@
 /* 자식 S,V,O,C를 갖는 S,V,O,C의 gcomment */
 .sem.outer[data-gc]::after {
 	position: absolute;
-	top: 1.9rem;
+	top: -0.625rem; /*1.9rem;*/
 	width: 9.375rem;
 	font-size: 0.625rem;
 }


### PR DESCRIPTION
자식 '성분'을 갖는 부모 '성분'의 gcomment 위치 수정.
줄높이에 대한 공식이 바뀌었으므로 일반 gcomment와 동일하게 적용.