### PR TITLE
Update tandem.editor.js

### DIFF
--- a/js/app/tandem.editor.js
+++ b/js/app/tandem.editor.js
@@ -403,7 +403,7 @@
 				   			pseudoHeight = parseFloat(pseudoStyle.height);
 				   		// 해당 코멘트에 실제 내용이 있고, 코멘트 위치나 크기가 있을 경우
 				   		if(target.dataset[type.data] != null 
-						&& !isNaN(pseudoVpos) && !isNaN(pseudoHpos)) {
+						&& !isNaN(pseudoWidth) && !isNaN(pseudoHeight)) {
 							// 코멘트의 4꼭지점 위치
 					   		var y1 = rects[isOdd][topOrBottm] + toUp * pseudoVpos;
 					   		var	y2 = y1 + toUp * pseudoHeight;


### PR DESCRIPTION
문제: 관계절 속에서 다시 절이 등장했을 때 수식선을 그으려 했을 때 그 부모 관계절의 rcomment 수정폼이 뜸.
코멘트 박스 인식에서
rcomment 내용은 있으나 표시는 되지 않는 태그를 인식하지 않도록.