### PR TITLE
Update tandem.js

### DIFF
--- a/js/app/tandem.js
+++ b/js/app/tandem.js
@@ -493,7 +493,7 @@
 					htmlTag += ` data-mfd="${semanticSequence}-${modificandIndex}"`;
 
 				if (tag.rcomment)
-					htmlTag += ` data-rc="${(tag.rcomment.indexOf('.') > 0) ? tag.rcomment : tag.rcomment.substring(0, 1).toUpperCase()}"`;
+					htmlTag += ` data-rc="${tag.rcomment.match(/\W/) ? tag.rcomment : tag.rcomment.substring(0, 1).toUpperCase()}"`;
 
 				if (tag.gcomment)
 					htmlTag += ` data-gc="${tag.gcomment}"`;


### PR DESCRIPTION
rcomment에 순수 알파벳만 있는 경우(Subj, Obj, ...)에만 1글자로 줄이고
아닌 경우엔(i.o., 진주어, ...) 그대로 표시