### PR TITLE
Update summernote.plugins.js

### DIFF
--- a/js/util/summernote.plugins.js
+++ b/js/util/summernote.plugins.js
@@ -18,10 +18,21 @@
 	$.extend($.summernote.plugins, {
         'brenter': function () {
             this.events = {
-                // Bind on ENTER
-                'summernote.enter': function (_we, e) {
-			      e.preventDefault();  
-			      $(this).summernote('pasteHTML', '<br>&#8203;');
+				// Bind on ENTER
+				'summernote.enter': function (_we, e) {
+					// default enter is <p></p>. so prevent it.
+					e.preventDefault();  
+					// First, insert <br>.
+					const br = document.createElement('BR')
+					$(this).summernote('insertNode', br);
+					// Second, remove all other ranges.
+					const sel = getSelection();
+					sel.removeAllRanges();
+					// Third, create a range of <br>, move cursor end of it.
+					const brRange = new Range();
+					brRange.setStartAfter(br);
+					sel.addRange(brRange);
+					sel.collapseToEnd();
                 }
             };
         }


### PR DESCRIPTION
써머노트에서 엔터를 치면 <br> 입력 하고 자동 커서 이동.
기존: <br>&ZeroWidthSpace; 입력