### PR TITLE
Update summernote.editor.js

### DIFF
--- a/js/util/summernote.editor.js
+++ b/js/util/summernote.editor.js
@@ -33,7 +33,7 @@
 			e.preventDefault();
 			// Firefox fix
 			setTimeout(function() {
-				$input.summernote('pasteHTML', bufferText.replaceAll(/\n/g, '<br/>'));
+				$input.summernote('pasteHTML', bufferText.replaceAll(/\r?\n/g, '<br/>'));
 			}, 10);
 		}		
 	}


### PR DESCRIPTION
붙여넣기시 \r\n을 <br>로 변경.
기존: \n만 <br>로 변경. -> \r로 인해 추가 줄바꿈이 있는 것으로 보였음.