### PR TITLE
Add files via upload

### DIFF
--- a/css/app/workbook.css
+++ b/css/app/workbook.css
@@ -1630,6 +1630,12 @@
 .note img{
 	max-width: 100%;
 }
+
+@media (max-width: 576px)  {
+    .note img{
+		width: 100%!important;
+	}
+}
 /*.full-text-section .note-block .note-mdf-btns{
 	background-color: #fff;
 	border-radius: 5px;


### PR DESCRIPTION
(머지 요청)
css/app/workbook.css

모바일 버전에서 지문상세보기의 노트 영역의 이미지는 width 100%로 보이도록 수정