### PR TITLE
Update craft-maker.js

### DIFF
--- a/js/app/craft-maker.js
+++ b/js/app/craft-maker.js
@@ -191,7 +191,7 @@
 		deleteList.forEach(k => command.delete(k));
 		command.append('ownerId', _memberId);
 		
-		if(fileInput.value != null) {
+		if(!!fileInput.value) {
 			new Compressor(fileInput.files[0], {
 				success(result) {
 					command.delete('coverImage');


### PR DESCRIPTION
coverImage가 비어있을 때에도 binary 형태로 전달되지 않도록