### PR TITLE
Update summernote.editor.js

### DIFF
--- a/js/util/summernote.editor.js
+++ b/js/util/summernote.editor.js
@@ -44,11 +44,11 @@
 				{
 					html: true, title: '<span class="fw-bold">※ 경고</span>',
 					trigger: 'manual',
-					content: '<span class="fw-bold text-danger">본문 내용이 너무 길어 마지막 입력이 취소되었습니다.</span>'
+					content: '<span class="fw-bold text-danger">본문 내용이 너무 깁니다.</span>'
 				});
 		$editable.attr('data-char-count', `현재 글자 수: ${contents.length} (스타일 정보 포함)`);
 		if (contents.length > maxContents) {
-			$input.summernote('undo');
+			//$input.summernote('undo');
 			setTimeout(() => popover.show(), 150);
 			$editable.blur();
 		} else popover.hide();		


### PR DESCRIPTION
본문 입력 길이가 제한보다 길 때 undo 함수를 실행했으나, 
초기 상태가 이미 초과인 경우 버그로 이어지므로 undo 함수실행은 취소하기로 함.