### PR TITLE
Update summernote.plugins.js

### DIFF
--- a/js/util/summernote.plugins.js
+++ b/js/util/summernote.plugins.js
@@ -49,7 +49,14 @@
 					brRange.setStartAfter(br);
 					sel.addRange(brRange);
 					sel.collapseToEnd();*/
-                }
+                },
+                // 탭 키 입력 시 고정길이 공백 입력이 아닌 진짜 탭 문자 적용(css로 white-space:pre를 적용해야 함.) 
+                'summernote.keydown': function(_we,e) {
+					if(e.code == 'Tab' && !e.shiftKey) {
+						$(this).summernote('pasteHTML','&#9;');
+						e.preventDefault();
+					}
+				}
             };
         }
     });


### PR DESCRIPTION
탭 키 입력 시 고정길이 공백 입력이 아닌 진짜 탭 문자 적용(css로 white-space:pre를 적용해야 함.)