### PR TITLE
데스크톱 이상 모니터 사이즈에서 지문 상세보기 페이지의 해석부분 너비 버그 수정

### DIFF
--- a/css/app/demo.css
+++ b/css/app/demo.css
@@ -1840,6 +1840,7 @@
     resize: none;
     padding: 10px;
 	width: calc(100vw - 20rem);
+	max-width: 100%;
 }
 .ai-translation-section{
 	display: inline-block;

--- a/css/app/demo.css
+++ b/css/app/demo.css
@@ -1839,7 +1839,7 @@
     border-radius: 10px;
     resize: none;
     padding: 10px;
-	width: calc(100vw - 20rem);
+	width: 100%;
 	max-width: 100%;
 }
 .ai-translation-section{


### PR DESCRIPTION
(머지요청)
css/app/demo.css

데스크톱 이상 모니터 사이즈에서 지문 상세보기 페이지의 해석부분 너비 버그 수정